### PR TITLE
Fix tasks length assertion

### DIFF
--- a/src/routes/tasks/tasks.test.ts
+++ b/src/routes/tasks/tasks.test.ts
@@ -82,7 +82,9 @@ describe("tasks routes", () => {
       const json = await response.json();
 
       expect(Array.isArray(json)).toBe(true);
-      expect(Array.isArray(json) && json.length).toBe(1);
+      if (Array.isArray(json)) {
+        expect(json).toHaveLength(1);
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- fix `tasks` route test by explicitly checking array length

## Testing
- `pnpm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ff2229d483309ec27856f31d775d